### PR TITLE
Add Experiment Definition (Fixes #23)

### DIFF
--- a/test/test-experiment-recipe-firefox.ts
+++ b/test/test-experiment-recipe-firefox.ts
@@ -1,5 +1,4 @@
 import {typeGuards} from "..";
-import {assert} from "chai";
 
 const TEST_EXPERIMENT = {
   "id": "ABOUTWELCOME-PULL-FACTOR-REINFORCEMENT-76-RELEASE",
@@ -11,21 +10,28 @@ const TEST_EXPERIMENT = {
     "experimentDocumentUrl": "https://experimenter.services.mozilla.com/experiments/aboutwelcome-pull-factor-reinforcement-76-release/",
     "userFacingDescription": "4 branch experiment different variants of about:welcome with a goal of testing new experiment framework and get insights on whether reinforcing pull-factors improves retention. Test deployment of multiple branches using new experiment framework",
     "isEnrollmentPaused": true,
+    "active": true,
+    "bucketConfig": {
+      "randomizationUnit": "normandy_id",
+      "namespace": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
+      "start": 0,
+      "count": 2000,
+      "total": 10000
+    },
+    "startDate": new Date(),
+    "endDate": null,
+    "proposedEnrollment": 7,
+    "referenceBranch": "control",
+    "features": [],
     "branches": [
       {
         "slug": "control",
         "ratio": 1,
-        "groups": [
-          "aboutwelcome"
-        ],
         "value": {}
       },
       {
         "slug": "treatment-variation-b",
         "ratio": 1,
-        "groups": [
-          "aboutwelcome"
-        ],
         "value": {}
       }
     ],
@@ -37,7 +43,7 @@ describe("experiment schemas", () => {
   it("should validate an existing onboarding experiment", async () => {
     const result = typeGuards.experiments_checkExperimentRecipe(TEST_EXPERIMENT);
     if (!result.ok) {
-      throw new Error(JSON.stringify(result.errors));
+      throw new Error(JSON.stringify(result.errors, null, 2));
     }
   });
 });

--- a/test/test-experiment-recipe-firefox.ts
+++ b/test/test-experiment-recipe-firefox.ts
@@ -1,0 +1,43 @@
+import {typeGuards} from "..";
+import {assert} from "chai";
+
+const TEST_EXPERIMENT = {
+  "id": "ABOUTWELCOME-PULL-FACTOR-REINFORCEMENT-76-RELEASE",
+  "enabled": true,
+  "filter_expression": "(env.version >= '76.' && env.version < '77.' && env.channel == 'release' && !(env.telemetry.main.environment.profile.creationDate < ('2020-05-13'|date / 1000 / 60 / 60 / 24))) || (locale == 'en-US' && [userId, \"aboutwelcome-pull-factor-reinforcement-76-release\"]|bucketSample(0, 2000, 10000) && (!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue) || 'bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77' in activeExperiments))",
+  "arguments": {
+    "slug": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
+    "userFacingName": "About:Welcome Pull Factor Reinforcement",
+    "experimentDocumentUrl": "https://experimenter.services.mozilla.com/experiments/aboutwelcome-pull-factor-reinforcement-76-release/",
+    "userFacingDescription": "4 branch experiment different variants of about:welcome with a goal of testing new experiment framework and get insights on whether reinforcing pull-factors improves retention. Test deployment of multiple branches using new experiment framework",
+    "isEnrollmentPaused": true,
+    "branches": [
+      {
+        "slug": "control",
+        "ratio": 1,
+        "groups": [
+          "aboutwelcome"
+        ],
+        "value": {}
+      },
+      {
+        "slug": "treatment-variation-b",
+        "ratio": 1,
+        "groups": [
+          "aboutwelcome"
+        ],
+        "value": {}
+      }
+    ],
+  },
+};
+
+
+describe("experiment schemas", () => {
+  it("should validate an existing onboarding experiment", async () => {
+    const result = typeGuards.experiments_checkExperimentRecipe(TEST_EXPERIMENT);
+    if (!result.ok) {
+      throw new Error(JSON.stringify(result.errors));
+    }
+  });
+});

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -1,8 +1,16 @@
 /**
- * The experiment definition accessible via the API and available to clients.fail
- * This is what Firefox reads from Remote Settings, or Pensieve gets via the public
- * Experimenter API.
+ * The experiment definition accessible to Firefox via Remote Settings.
+ * It is compatible with ExperimentManager.
  */
+export interface ExperimentRecipe {
+  /** A unique identifier for the Recipe */
+  id: string;
+  /** JEXL expression defined in an Audience */
+  filter_expression: string;
+  /** Experiment definition */
+  arguments: Experiment;
+}
+
 export interface Experiment {
   /** Unique identifier for the experiment */
   slug: string;
@@ -12,30 +20,22 @@ export interface Experiment {
   public_description: string;
   /** Experimenter URL */
   experiment_url: string;
-
   /** Is the experiment currently live in production? i.e., published to remote settings? */
   is_published: boolean;
   /** Are we continuing to enroll new users into the experiment? */
-  is_enrollment_paused: boolean;
-
-  /** Reference to an Audience, which contains targeting information */
-  audience: Audience;
+  isEnrollmentPaused: boolean;
   /** Bucketing configuration */
   bucket_config: BucketConfig;
-
   /** A list of features relevant to the experiment analysis */
   features: Array<Feature>;
   /** Branch configuration for the experiment */
   branches: Array<Branch>;
-
   /** Actual publish date of the experiment */
   start_date: Date;
-
-  /** Duration of enrollment from the start date */
-  proposed_enrollment: number;
-
   /** Actual end date of the experiment */
   end_date: Date | null;
+  /** Duration of enrollment from the start date in days */
+  proposed_enrollment: number;
 }
 
 // TODO - Needs to be generated based on Features to be added to the /data directory
@@ -43,23 +43,21 @@ export interface Experiment {
 type Feature = string;
 
 interface BucketConfig {
+  /**
+   * The randomization unit. Note that client_id is not yet implemented.
+   * @default "normandy_id"
+   */
   randomization_unit: "client_id" | "normandy_id";
+  /** Additional inputs to the hashing function */
   namespace: string;
+  /**  Index of start of the range of buckets */
   start: number;
+  /**  Number of buckets to check */
   count: number;
   /**
    * Total number of buckets
    * @default 10000  */
   total: number;
-}
-
-export interface Audience {
-  /** Human-readable name of the audience */
-  name: string;
-  /** Human-readable description */
-  description: string;
-  /** A targeting expression written in jexl */
-  filter_expression: string;
 }
 
 interface Branch {
@@ -74,6 +72,6 @@ interface Branch {
    */
   ratio: number;
   /** The variant payload. TODO: This will be more strictly validated. */
-  value: {[key: string]: any};
+  value: {[key: string]: any} | null;
 }
 

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -7,6 +7,8 @@ export interface ExperimentRecipe {
   id: string;
   /** JEXL expression defined in an Audience */
   filter_expression: string;
+  /** Is the experiment enabled? */
+  enabled: boolean;
   /** Experiment definition */
   arguments: Experiment;
 }
@@ -15,13 +17,13 @@ export interface Experiment {
   /** Unique identifier for the experiment */
   slug: string;
   /** Publically-accesible name of the experiment */
-  publicName: string;
+  userFacingName: string;
   /** Short public description of the experiment */
-  publicDescription: string;
+  userFacingDescription: string;
   /** Experimenter URL */
-  experimentUrl: string;
+  experimentDocumentUrl: string;
   /** Is the experiment currently live in production? i.e., published to remote settings? */
-  isPublished: boolean;
+  active: boolean;
   /** Are we continuing to enroll new users into the experiment? */
   isEnrollmentPaused: boolean;
   /** Bucketing configuration */
@@ -72,6 +74,9 @@ interface Branch {
    * @default 1
    */
   ratio: number;
+  /** Deprecated - used to indicate a type of value */
+  group?: Array<"cfr"|"aboutwelcome">;
   /** The variant payload. TODO: This will be more strictly validated. */
   value: {[key: string]: any} | null;
 }
+

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -15,27 +15,29 @@ export interface Experiment {
   /** Unique identifier for the experiment */
   slug: string;
   /** Publically-accesible name of the experiment */
-  public_name: string;
+  publicName: string;
   /** Short public description of the experiment */
-  public_description: string;
+  publicDescription: string;
   /** Experimenter URL */
-  experiment_url: string;
+  experimentUrl: string;
   /** Is the experiment currently live in production? i.e., published to remote settings? */
-  is_published: boolean;
+  isPublished: boolean;
   /** Are we continuing to enroll new users into the experiment? */
   isEnrollmentPaused: boolean;
   /** Bucketing configuration */
-  bucket_config: BucketConfig;
+  bucketConfig: BucketConfig;
   /** A list of features relevant to the experiment analysis */
   features: Array<Feature>;
   /** Branch configuration for the experiment */
   branches: Array<Branch>;
   /** Actual publish date of the experiment */
-  start_date: Date;
+  startDate: Date;
   /** Actual end date of the experiment */
-  end_date: Date | null;
+  endDate: Date | null;
   /** Duration of enrollment from the start date in days */
-  proposed_enrollment: number;
+  proposedEnrollment: number;
+  /** The slug of the reference branch */
+  referenceBranch: string | null;
 }
 
 // TODO - Needs to be generated based on Features to be added to the /data directory
@@ -47,7 +49,7 @@ interface BucketConfig {
    * The randomization unit. Note that client_id is not yet implemented.
    * @default "normandy_id"
    */
-  randomization_unit: "client_id" | "normandy_id";
+  randomizationUnit: "client_id" | "normandy_id";
   /** Additional inputs to the hashing function */
   namespace: string;
   /**  Index of start of the range of buckets */
@@ -61,10 +63,9 @@ interface BucketConfig {
 }
 
 interface Branch {
-  /** Display name for variant, e.g. "control"  */
+  /** Identifier for the branch */
   slug: string;
-  /** Is this a reference/"control" branch? */
-  is_control?: boolean;
+  /** Display name for variant, e.g. "control"  */
   /**
    * Relative ratio of population for the branch (e.g. if branch A=1 and branch B=3,
    * branch A would get 25% of the population)
@@ -74,4 +75,3 @@ interface Branch {
   /** The variant payload. TODO: This will be more strictly validated. */
   value: {[key: string]: any} | null;
 }
-

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -38,16 +38,6 @@ export interface Experiment {
   end_date: Date | null;
 }
 
-/**
- * This is the Internal Experiment type used by the front-end.
- * It has some additional fields not included in the public api.
- */
-export interface ExperimentInternal extends Experiment {
-  /** Hypothesis for the experiment */
-  objectives: string;
-}
-
-
 // TODO - Needs to be generated based on Features to be added to the /data directory
 // probably like keyof typeof Features
 type Feature = string;
@@ -76,7 +66,7 @@ interface Branch {
   /** Display name for variant, e.g. "control"  */
   slug: string;
   /** Is this a reference/"control" branch? */
-  is_reference_branch: string;
+  is_control?: boolean;
   /**
    * Relative ratio of population for the branch (e.g. if branch A=1 and branch B=3,
    * branch A would get 25% of the population)

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -1,0 +1,75 @@
+/** All fields are publically accessible via the API and available to clients */
+export interface Experiment {
+  /** Unique identifier for the experiment */
+  slug: string;
+  /** Publically-accesible name of the experiment */
+  public_name: string;
+  /** Short public description of the experiment */
+  public_description: string;
+  /** Experimenter URL */
+  experiment_url: string;
+
+  /** Is the experiment currently live in production? i.e., published to remote settings? */
+  is_published: boolean;
+  /** Are we continuing to enroll new users into the experiment? */
+  is_enrollment_paused: boolean;
+
+  /** Reference to an Audience, which contains targeting information */
+  audience: Audience;
+  /** Bucketing configuration */
+  bucket_config: BucketConfig;
+
+  /** A list of features relevant to the experiment analysis */
+  features: Array<Feature>;
+  /** Branch configuration for the experiment */
+  branches: Array<Branch>;
+
+  /** Actual publish date of the experiment */
+  start_date: Date;
+
+  /** Duration of enrollment from the start date */
+  proposed_enrollment: number;
+
+  /** Actual end date of the experiment */
+  end_date: Date | null;
+}
+
+// TODO - Needs to be generated based on Features to be added to the /data directory
+// probably like keyof typeof Features
+type Feature = string;
+
+interface BucketConfig {
+  randomization_unit: "client_id" | "normandy_id";
+  namespace: string;
+  start: number;
+  count: number;
+  /**
+   * Total number of buckets
+   * @default 10000  */
+  total: number;
+}
+
+export interface Audience {
+  /** Human-readable name of the audience */
+  name: string;
+  /** Human-readable description */
+  description: string;
+  /** A targeting expression written in jexl */
+  filter_expression: string;
+}
+
+interface Branch {
+  /** Display name for variant, e.g. "control"  */
+  slug: string;
+  /** Is this a reference/"control" branch? */
+  is_reference_branch: string;
+  /**
+   * Relative ratio of population for the branch (e.g. if branch A=1 and branch B=3,
+   * branch A would get 25% of the population)
+   * @default 1
+   */
+  ratio: number;
+  /** The variant payload. TODO: This will be more strictly validated. */
+  value: {[key: string]: any};
+}
+

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -1,4 +1,8 @@
-/** All fields are publically accessible via the API and available to clients */
+/**
+ * The experiment definition accessible via the API and available to clients.fail
+ * This is what Firefox reads from Remote Settings, or Pensieve gets via the public
+ * Experimenter API.
+ */
 export interface Experiment {
   /** Unique identifier for the experiment */
   slug: string;
@@ -33,6 +37,16 @@ export interface Experiment {
   /** Actual end date of the experiment */
   end_date: Date | null;
 }
+
+/**
+ * This is the Internal Experiment type used by the front-end.
+ * It has some additional fields not included in the public api.
+ */
+export interface ExperimentInternal extends Experiment {
+  /** Hypothesis for the experiment */
+  objectives: string;
+}
+
 
 // TODO - Needs to be generated based on Features to be added to the /data directory
 // probably like keyof typeof Features


### PR DESCRIPTION
This needs some discussion and is likely to change as we start thinking more broadly about mobile etc. but I think we should define what we think an `Experiment` will look like so we can stay coordinated across applications. Some notes:

* We need to define what subset gets sychronized to client configs v.s. a broader set of data that is available to applications like Pensieve
* Although we want to make this practical for right now, we should keep in mind that long term this should not be specific to a particular client (i.e., it should be suitable for Desktop + Mobile) or a particular feature implementation (e.g., Messaging).

Anyways, ready for initial feedback. Thoughts @jaredlockhart @tdsmith @mythmon @piatra? 
