### PR TITLE
Added experiment design data for A/A (fix #24)

### DIFF
--- a/data/ExperimentDesignPresets.ts
+++ b/data/ExperimentDesignPresets.ts
@@ -1,0 +1,26 @@
+import {AAExperiment} from "../types/experiments";
+
+interface Preset<T> {
+  name: string;
+  description: string;
+  presets: Partial<T>
+}
+
+export const AAType: Preset<AAExperiment> = {
+  name: "A/A Experiment",
+  description: "A design for diagnostic testing of targeting or enrollment. Fixed to 1% of the population.",
+  presets: {
+    branches: [
+      {slug: "control", is_reference_branch: true, ratio: 1, value: {}},
+      {slug: "treatment", ratio: 1, value: {}}
+    ],
+    bucket_config: {
+      randomization_unit: "normandy_id",
+      // This needs to be generated based on the slug.
+      namespace: "",
+      start: 0,
+      count: 100,
+      total: 10000
+    }
+  }
+};

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -1,8 +1,16 @@
 /**
- * The experiment definition accessible via the API and available to clients.fail
- * This is what Firefox reads from Remote Settings, or Pensieve gets via the public
- * Experimenter API.
+ * The experiment definition accessible to Firefox via Remote Settings.
+ * It is compatible with ExperimentManager.
  */
+export interface ExperimentRecipe {
+  /** A unique identifier for the Recipe */
+  id: string;
+  /** JEXL expression defined in an Audience */
+  filter_expression: string;
+  /** Experiment definition */
+  arguments: Experiment;
+}
+
 export interface Experiment {
   /** Unique identifier for the experiment */
   slug: string;
@@ -12,30 +20,22 @@ export interface Experiment {
   public_description: string;
   /** Experimenter URL */
   experiment_url: string;
-
   /** Is the experiment currently live in production? i.e., published to remote settings? */
   is_published: boolean;
   /** Are we continuing to enroll new users into the experiment? */
-  is_enrollment_paused: boolean;
-
-  /** Reference to an Audience, which contains targeting information */
-  audience: Audience;
+  isEnrollmentPaused: boolean;
   /** Bucketing configuration */
   bucket_config: BucketConfig;
-
   /** A list of features relevant to the experiment analysis */
   features: Array<Feature>;
   /** Branch configuration for the experiment */
   branches: Array<Branch>;
-
   /** Actual publish date of the experiment */
   start_date: Date;
-
-  /** Duration of enrollment from the start date */
-  proposed_enrollment: number;
-
   /** Actual end date of the experiment */
   end_date: Date | null;
+  /** Duration of enrollment from the start date in days */
+  proposed_enrollment: number;
 }
 
 // TODO - Needs to be generated based on Features to be added to the /data directory
@@ -43,23 +43,21 @@ export interface Experiment {
 type Feature = string;
 
 interface BucketConfig {
+  /**
+   * The randomization unit. Note that client_id is not yet implemented.
+   * @default "normandy_id"
+   */
   randomization_unit: "client_id" | "normandy_id";
+  /** Additional inputs to the hashing function */
   namespace: string;
+  /**  Index of start of the range of buckets */
   start: number;
+  /**  Number of buckets to check */
   count: number;
   /**
    * Total number of buckets
    * @default 10000  */
   total: number;
-}
-
-export interface Audience {
-  /** Human-readable name of the audience */
-  name: string;
-  /** Human-readable description */
-  description: string;
-  /** A targeting expression written in jexl */
-  filter_expression: string;
 }
 
 interface Branch {
@@ -74,6 +72,6 @@ interface Branch {
    */
   ratio: number;
   /** The variant payload. TODO: This will be more strictly validated. */
-  value: {[key: string]: any};
+  value: {[key: string]: any} | null;
 }
 

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -36,6 +36,8 @@ export interface Experiment {
   end_date: Date | null;
   /** Duration of enrollment from the start date in days */
   proposed_enrollment: number;
+  /** The slug of the reference branch */
+  reference_branch: string | null;
 }
 
 // TODO - Needs to be generated based on Features to be added to the /data directory
@@ -61,10 +63,9 @@ interface BucketConfig {
 }
 
 interface Branch {
-  /** Display name for variant, e.g. "control"  */
+  /** Identifier for the branch */
   slug: string;
-  /** Is this a reference/"control" branch? */
-  is_control?: boolean;
+  /** Display name for variant, e.g. "control"  */
   /**
    * Relative ratio of population for the branch (e.g. if branch A=1 and branch B=3,
    * branch A would get 25% of the population)

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -38,16 +38,6 @@ export interface Experiment {
   end_date: Date | null;
 }
 
-/**
- * This is the Internal Experiment type used by the front-end.
- * It has some additional fields not included in the public api.
- */
-export interface ExperimentInternal extends Experiment {
-  /** Hypothesis for the experiment */
-  objectives: string;
-}
-
-
 // TODO - Needs to be generated based on Features to be added to the /data directory
 // probably like keyof typeof Features
 type Feature = string;
@@ -76,7 +66,7 @@ interface Branch {
   /** Display name for variant, e.g. "control"  */
   slug: string;
   /** Is this a reference/"control" branch? */
-  is_reference_branch: string;
+  is_control?: boolean;
   /**
    * Relative ratio of population for the branch (e.g. if branch A=1 and branch B=3,
    * branch A would get 25% of the population)

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -1,0 +1,75 @@
+/** All fields are publically accessible via the API and available to clients */
+export interface Experiment {
+  /** Unique identifier for the experiment */
+  slug: string;
+  /** Publically-accesible name of the experiment */
+  public_name: string;
+  /** Short public description of the experiment */
+  public_description: string;
+  /** Experimenter URL */
+  experiment_url: string;
+
+  /** Is the experiment currently live in production? i.e., published to remote settings? */
+  is_published: boolean;
+  /** Are we continuing to enroll new users into the experiment? */
+  is_enrollment_paused: boolean;
+
+  /** Reference to an Audience, which contains targeting information */
+  audience: Audience;
+  /** Bucketing configuration */
+  bucket_config: BucketConfig;
+
+  /** A list of features relevant to the experiment analysis */
+  features: Array<Feature>;
+  /** Branch configuration for the experiment */
+  branches: Array<Branch>;
+
+  /** Actual publish date of the experiment */
+  start_date: Date;
+
+  /** Duration of enrollment from the start date */
+  proposed_enrollment: number;
+
+  /** Actual end date of the experiment */
+  end_date: Date | null;
+}
+
+// TODO - Needs to be generated based on Features to be added to the /data directory
+// probably like keyof typeof Features
+type Feature = string;
+
+interface BucketConfig {
+  randomization_unit: "client_id" | "normandy_id";
+  namespace: string;
+  start: number;
+  count: number;
+  /**
+   * Total number of buckets
+   * @default 10000  */
+  total: number;
+}
+
+export interface Audience {
+  /** Human-readable name of the audience */
+  name: string;
+  /** Human-readable description */
+  description: string;
+  /** A targeting expression written in jexl */
+  filter_expression: string;
+}
+
+interface Branch {
+  /** Display name for variant, e.g. "control"  */
+  slug: string;
+  /** Is this a reference/"control" branch? */
+  is_reference_branch: string;
+  /**
+   * Relative ratio of population for the branch (e.g. if branch A=1 and branch B=3,
+   * branch A would get 25% of the population)
+   * @default 1
+   */
+  ratio: number;
+  /** The variant payload. TODO: This will be more strictly validated. */
+  value: {[key: string]: any};
+}
+

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -75,3 +75,15 @@ interface Branch {
   value: {[key: string]: any} | null;
 }
 
+/**
+ * Preset types
+ * */
+export type ExperimentTypes = AAExperiment | Experiment;
+
+export interface AAExperiment extends Experiment {
+  branches: Array<AABranch>;
+}
+
+interface AABranch extends Branch {
+  value: {}
+}

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -15,29 +15,29 @@ export interface Experiment {
   /** Unique identifier for the experiment */
   slug: string;
   /** Publically-accesible name of the experiment */
-  public_name: string;
+  publicName: string;
   /** Short public description of the experiment */
-  public_description: string;
+  publicDescription: string;
   /** Experimenter URL */
-  experiment_url: string;
+  experimentUrl: string;
   /** Is the experiment currently live in production? i.e., published to remote settings? */
-  is_published: boolean;
+  isPublished: boolean;
   /** Are we continuing to enroll new users into the experiment? */
   isEnrollmentPaused: boolean;
   /** Bucketing configuration */
-  bucket_config: BucketConfig;
+  bucketConfig: BucketConfig;
   /** A list of features relevant to the experiment analysis */
   features: Array<Feature>;
   /** Branch configuration for the experiment */
   branches: Array<Branch>;
   /** Actual publish date of the experiment */
-  start_date: Date;
+  startDate: Date;
   /** Actual end date of the experiment */
-  end_date: Date | null;
+  endDate: Date | null;
   /** Duration of enrollment from the start date in days */
-  proposed_enrollment: number;
+  proposedEnrollment: number;
   /** The slug of the reference branch */
-  reference_branch: string | null;
+  referenceBranch: string | null;
 }
 
 // TODO - Needs to be generated based on Features to be added to the /data directory
@@ -49,7 +49,7 @@ interface BucketConfig {
    * The randomization unit. Note that client_id is not yet implemented.
    * @default "normandy_id"
    */
-  randomization_unit: "client_id" | "normandy_id";
+  randomizationUnit: "client_id" | "normandy_id";
   /** Additional inputs to the hashing function */
   namespace: string;
   /**  Index of start of the range of buckets */

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -85,5 +85,5 @@ export interface AAExperiment extends Experiment {
 }
 
 interface AABranch extends Branch {
-  value: {}
+  value: null
 }

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -1,4 +1,8 @@
-/** All fields are publically accessible via the API and available to clients */
+/**
+ * The experiment definition accessible via the API and available to clients.fail
+ * This is what Firefox reads from Remote Settings, or Pensieve gets via the public
+ * Experimenter API.
+ */
 export interface Experiment {
   /** Unique identifier for the experiment */
   slug: string;
@@ -33,6 +37,16 @@ export interface Experiment {
   /** Actual end date of the experiment */
   end_date: Date | null;
 }
+
+/**
+ * This is the Internal Experiment type used by the front-end.
+ * It has some additional fields not included in the public api.
+ */
+export interface ExperimentInternal extends Experiment {
+  /** Hypothesis for the experiment */
+  objectives: string;
+}
+
 
 // TODO - Needs to be generated based on Features to be added to the /data directory
 // probably like keyof typeof Features


### PR DESCRIPTION
This is sort of along the lines of what I was thinking for experiment design presets, i.e. some UI-specific configurations (like max or non-editable values). 

Obviously some logic for the UI will need to be computed in code, so we could also just store these directly in experimenter if it makes more sense.

For now this would be the only one that exists but eventually it would show up in a list of "pre-canned options": 
![image](https://user-images.githubusercontent.com/1455535/84053468-f2f05980-a97f-11ea-8300-c85388ea51e9.png)


