### PR TITLE
Experiment definition, fixes #23

### DIFF
--- a/test/test-experiment-recipe-firefox.ts
+++ b/test/test-experiment-recipe-firefox.ts
@@ -1,0 +1,45 @@
+import {typeGuards} from "..";
+
+const TEST_EXPERIMENT = {
+  "id": "ABOUTWELCOME-PULL-FACTOR-REINFORCEMENT-76-RELEASE",
+  "enabled": true,
+  "filter_expression": "(env.version >= '76.' && env.version < '77.' && env.channel == 'release' && !(env.telemetry.main.environment.profile.creationDate < ('2020-05-13'|date / 1000 / 60 / 60 / 24))) || (locale == 'en-US' && [userId, \"aboutwelcome-pull-factor-reinforcement-76-release\"]|bucketSample(0, 2000, 10000) && (!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue) || 'bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77' in activeExperiments))",
+  "arguments": {
+    "slug": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
+    "userFacingName": "About:Welcome Pull Factor Reinforcement",
+    "userFacingDescription": "4 branch experiment different variants of about:welcome with a goal of testing new experiment framework and get insights on whether reinforcing pull-factors improves retention. Test deployment of multiple branches using new experiment framework",
+    "isEnrollmentPaused": true,
+    "active": true,
+    "bucketConfig": {
+      "randomizationUnit": "normandy_id",
+      "namespace": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
+      "start": 0,
+      "count": 2000,
+      "total": 10000
+    },
+    "startDate": new Date(),
+    "endDate": null,
+    "proposedEnrollment": 7,
+    "referenceBranch": "control",
+    "features": [],
+    "branches": [
+      {
+        "slug": "control",
+        "ratio": 1,
+        "value": {}
+      },
+      {
+        "slug": "treatment-variation-b",
+        "ratio": 1,
+        "value": {}
+      }
+    ],
+  },
+};
+
+
+describe("experiment schemas", () => {
+  it("should validate an existing onboarding experiment", async () => {
+    typeGuards.experiments_assertExperimentRecipe(TEST_EXPERIMENT);
+  });
+});

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -1,0 +1,86 @@
+/**
+ * The experiment definition accessible to Firefox via Remote Settings.
+ * It is compatible with ExperimentManager.
+ */
+export interface ExperimentRecipe {
+  /** A unique identifier for the Recipe */
+  id: string;
+  /** JEXL expression defined in an Audience */
+  filter_expression: string;
+  /**
+   * JEXL expression using messaging system environment
+   * @deprecated */
+  targeting?: string;
+  /** Is the experiment enabled? */
+  enabled: boolean;
+  /** Experiment definition */
+  arguments: Experiment;
+}
+
+export interface Experiment {
+  /** Unique identifier for the experiment */
+  slug: string;
+  /** Publically-accesible name of the experiment */
+  userFacingName: string;
+  /** Short public description of the experiment */
+  userFacingDescription: string;
+  /** Is the experiment currently live in production? i.e., published to remote settings? */
+  active: boolean;
+  /** Are we continuing to enroll new users into the experiment? */
+  isEnrollmentPaused: boolean;
+  /** Bucketing configuration */
+  bucketConfig: BucketConfig;
+  /** A list of features relevant to the experiment analysis */
+  features: Array<Feature>;
+  /** Branch configuration for the experiment */
+  branches: Array<Branch>;
+  /** Actual publish date of the experiment */
+  startDate: Date;
+  /** Actual end date of the experiment */
+  endDate: Date | null;
+  /** Duration of enrollment from the start date in days */
+  proposedEnrollment: number;
+  /** The slug of the reference branch */
+  referenceBranch: string | null;
+}
+
+// TODO - Needs to be generated based on Features to be added to the /data directory
+// probably like keyof typeof Features
+type Feature = string;
+
+interface BucketConfig {
+  /**
+   * The randomization unit. Note that client_id is not yet implemented.
+   * @default "normandy_id"
+   */
+  randomizationUnit: "client_id" | "normandy_id";
+  /** Additional inputs to the hashing function */
+  namespace: string;
+  /**  Index of start of the range of buckets */
+  start: number;
+  /**  Number of buckets to check */
+  count: number;
+  /**
+   * Total number of buckets
+   * @default 10000  */
+  total: number;
+}
+
+interface Branch {
+  /** Identifier for the branch */
+  slug: string;
+  /**
+   * Relative ratio of population for the branch (e.g. if branch A=1 and branch B=3,
+   * branch A would get 25% of the population)
+   * @default 1
+   */
+  ratio: number;
+  /**
+   * Used to indicate a type of branch value
+   * @deprecated
+   */
+  group?: Array<"cfr"|"aboutwelcome">;
+  /** The variant payload. TODO: This will be more strictly validated. */
+  value: {[key: string]: any} | null;
+}
+


### PR DESCRIPTION
Adds an experiment definition compatible with the current Firefox implementation.

See https://github.com/mozilla/nimbus-shared/pull/19 for previously closed PR (due to branch renaming)