### PR TITLE
Design preset for A/A Experiment

### DIFF
--- a/data/ExperimentDesignPresets.ts
+++ b/data/ExperimentDesignPresets.ts
@@ -1,0 +1,35 @@
+import {ExperimentDesign} from "../types/experiments";
+
+// Utility type to being able to specify partials of nested objects
+type RecursivePartial<T> = {
+  [P in keyof T]?:
+    T[P] extends Array<infer U> ? Array<RecursivePartial<U>> :
+    T[P] extends {[key: string]: any} ? RecursivePartial<T[P]> :
+    T[P];
+};
+
+// Utility type for specifiying a partial of any experiment design
+interface Preset<T> {
+  name: string;
+  description: string;
+  preset: RecursivePartial<T>
+}
+
+const presets :  {[id: string] : Preset<ExperimentDesign> } = {
+  empty_aa: {
+    name: "A/A Experiment",
+    description: "A design for diagnostic testing of targeting or enrollment. Fixed to 1% of the population.",
+    preset: {
+      branches: [
+        {slug: "control", ratio: 1, value: null},
+        {slug: "treatment", ratio: 1, value: null}
+      ],
+      bucketConfig: {
+        randomizationUnit: "normandy_id",
+        total: 10000
+      }
+    }
+  }
+};
+
+export default presets;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["index.ts", "types", "src"],
+  "include": ["index.ts", "types", "src", "data"],
   "exclude": ["node_modules"],
   "compilerOptions": {
     "outDir": "dist",

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -85,3 +85,26 @@ interface Branch {
   /** The variant payload. TODO: This will be more strictly validated. */
   value: {[key: string]: any} | null;
 }
+
+/**
+ * Preset types
+ * */
+
+// A union of all available experiment designs; right now there is only one.
+export type ExperimentDesign = EmptyAAExperiment;
+
+/**
+ * An empty experiment that can target a maximum of 1% of the population
+ */
+export interface EmptyAAExperiment extends Experiment {
+  branches: Array<EmptyBranch>;
+  bucketConfig: AABucketConfig;
+}
+
+interface AABucketConfig extends BucketConfig {
+  total: 10000
+}
+
+interface EmptyBranch extends Branch {
+  value: null
+}


### PR DESCRIPTION
Includes:
* Empty branch type
* Max value of 1% of the population
* Preset of 2 equal empty branches

In terms of implementation, using typesscript for this doesn't work particularly well if we want to generate everything on the python side (although it could be used for validation).

Note that this design has been reviewed / approved by @tdsmith 