### PR TITLE
Find audience sizes with telemetry

### DIFF
--- a/data/Audiences.ts
+++ b/data/Audiences.ts
@@ -3,23 +3,32 @@ interface Audience {
   description: string;
   targeting?: string;
   filter_expression?: string;
+  /**
+   * A boolean SQL expression expressing whether a single row in telemetry.main would have
+   * matched the audience definition. These are used for sizing experiment populations,
+   * not for targeting.
+   */
+  desktop_telemetry?: string;
 }
 
 const audiences :  {[id: string] : Audience } = {
   all_english: {
     name: "All English users",
     description: "All users in en-* locales.",
-    targeting: "localeLanguageCode == \"en\""
+    targeting: "localeLanguageCode == \"en\"",
+    desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en')"
   },
   us_only: {
     name: "US users (en)",
     description: "All users in the US with an en-* locale.",
-    targeting: "localeLanguageCode == \"en\" && region == \"US\""
+    targeting: "localeLanguageCode == \"en\" && region == \"US\"",
+    desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en') AND normalized_country_code = 'US'"
   },
   first_run: {
     name: "First start-up users (en)",
     description: "First start-up users (e.g. for about:welcome) with an en-* locale.",
-    targeting: "localeLanguageCode == \"en\" && (isFirstStartup || currentExperiment.slug in activeExperiments) "
+    targeting: "localeLanguageCode == \"en\" && (isFirstStartup || currentExperiment.slug in activeExperiments) ",
+    desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en') AND payload.info.profile_subsession_counter = 1"
   }
 };
 

--- a/data/Audiences.ts
+++ b/data/Audiences.ts
@@ -1,15 +1,4 @@
-interface Audience {
-  name: string;
-  description: string;
-  targeting?: string;
-  filter_expression?: string;
-  /**
-   * A boolean BigQuery SQL expression expressing whether a single row in telemetry.main would have
-   * matched the audience definition. These are used for sizing experiment populations,
-   * not for targeting.
-   */
-  desktop_telemetry?: string;
-}
+import { Audience } from "../types/targeting";
 
 const audiences :  {[id: string] : Audience } = {
   all_english: {

--- a/data/Audiences.ts
+++ b/data/Audiences.ts
@@ -4,7 +4,7 @@ interface Audience {
   targeting?: string;
   filter_expression?: string;
   /**
-   * A boolean SQL expression expressing whether a single row in telemetry.main would have
+   * A boolean BigQuery SQL expression expressing whether a single row in telemetry.main would have
    * matched the audience definition. These are used for sizing experiment populations,
    * not for targeting.
    */

--- a/data/Audiences.ts
+++ b/data/Audiences.ts
@@ -15,19 +15,19 @@ const audiences :  {[id: string] : Audience } = {
   all_english: {
     name: "All English users",
     description: "All users in en-* locales.",
-    targeting: "localeLanguageCode == \"en\"",
+    targeting: "localeLanguageCode == 'en'",
     desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en')"
   },
   us_only: {
     name: "US users (en)",
     description: "All users in the US with an en-* locale.",
-    targeting: "localeLanguageCode == \"en\" && region == \"US\"",
+    targeting: "localeLanguageCode == 'en' && region == 'US'",
     desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en') AND normalized_country_code = 'US'"
   },
   first_run: {
     name: "First start-up users (en)",
     description: "First start-up users (e.g. for about:welcome) with an en-* locale.",
-    targeting: "localeLanguageCode == \"en\" && (isFirstStartup || currentExperiment.slug in activeExperiments) ",
+    targeting: "localeLanguageCode == 'en' && (isFirstStartup || currentExperiment.slug in activeExperiments)",
     desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en') AND payload.info.profile_subsession_counter = 1"
   }
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,2 +1,3 @@
 export * as normandy from "./normandy";
 export * as messaging from "./messaging";
+export * as targeting from "./targeting";

--- a/types/targeting.ts
+++ b/types/targeting.ts
@@ -1,0 +1,12 @@
+export interface Audience {
+    name: string;
+    description: string;
+    targeting?: string;
+    filter_expression?: string;
+    /**
+     * A boolean BigQuery SQL expression expressing whether a single row in telemetry.main would have
+     * matched the audience definition. These are used for sizing experiment populations,
+     * not for targeting.
+     */
+    desktop_telemetry?: string;
+  }


### PR DESCRIPTION
Providing SQL expressions in audience definitions that let us test group memberships will facilitate automatically sizing experiments.