### PR TITLE
Add feature types and some examples

### DIFF
--- a/data/features/__nimbusMeta.toml
+++ b/data/features/__nimbusMeta.toml
@@ -1,2 +1,2 @@
-type = "features/FeatureInterface"
+type = "features/Feature"
 useFilenameForSlug = true

--- a/data/features/__nimbusMeta.toml
+++ b/data/features/__nimbusMeta.toml
@@ -1,0 +1,2 @@
+type = "features/FeatureInterface"
+useFilenameForSlug = true

--- a/data/features/picture_in_picture.toml
+++ b/data/features/picture_in_picture.toml
@@ -1,0 +1,12 @@
+name = "Picture-in-Picture"
+description = """
+Counts the fraction of users and the number of times that users open Picture-in-Picture
+windows from videos. PiP can be opened by clicking on the PiP overlay or the video's context
+menu.
+"""
+
+[[telemetry]]
+kind = "event"
+event_category = "pictureinpicture"
+event_method = "create"
+event_object = "player"

--- a/data/features/pinned_tabs.toml
+++ b/data/features/pinned_tabs.toml
@@ -1,0 +1,9 @@
+name = "Pinned tabs"
+description = """
+Counts the number of times that a client pinned a tab. This doesn't measure whether users
+already had tabs pinned when observation began.
+"""
+
+[[telemetry]]
+kind = "scalar"
+name = "browser.engagement.tab_pinned_event_count"

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -30,8 +30,8 @@ export interface Experiment {
   isEnrollmentPaused: boolean;
   /** Bucketing configuration */
   bucketConfig: BucketConfig;
-  /** A list of features relevant to the experiment analysis */
-  features: Array<Feature>;
+  /** A list of feature slugs relevant to the experiment analysis */
+  features: Array<string>;
   /** Branch configuration for the experiment */
   branches: Array<Branch>;
   /**
@@ -49,10 +49,6 @@ export interface Experiment {
   /** The slug of the reference branch */
   referenceBranch: string | null;
 }
-
-// TODO - Needs to be generated based on Features to be added to the /data directory
-// probably like keyof typeof Features
-type Feature = string;
 
 interface BucketConfig {
   /**
@@ -89,4 +85,3 @@ interface Branch {
   /** The variant payload. TODO: This will be more strictly validated. */
   value: {[key: string]: any} | null;
 }
-

--- a/types/features.ts
+++ b/types/features.ts
@@ -1,4 +1,4 @@
-export interface FeatureInterface {
+export interface Feature {
   /** Should match the filename of the feature definition */
   slug: string;
 

--- a/types/features.ts
+++ b/types/features.ts
@@ -1,0 +1,41 @@
+export interface FeatureInterface {
+  /** Should match the filename of the feature definition */
+  slug: string;
+
+  /** Human-readable short name */
+  name: string;
+
+  /** Longer description of the feature under measure */
+  description: string;
+
+  /** Telemetry indicating whether the feature was used */
+  telemetry: Array<FeatureTelemetry>;
+}
+
+type FeatureTelemetry = FeatureEventTelemetry | FeatureScalarTelemetry;
+
+interface FeatureEventTelemetry {
+  kind: "event";
+
+  /** Category of the event to match */
+  event_category: string;
+
+  /** Method of the event to match. If provided, must match exactly */
+  event_method?: string;
+
+  /** Object of the event to match. If provided, must match exactly */
+  event_object?: string;
+
+  /** String value of the event to match. If provided, must match exactly */
+  event_value?: string;
+}
+
+interface FeatureScalarTelemetry {
+  kind: "scalar";
+
+  /**
+   * Name of the scalar to match, in dot-separated form, like
+    `browser.engagement.tab_pinned_event_count`.
+   */
+  name: string;
+}


### PR DESCRIPTION
Based on the spec draft in https://docs.google.com/document/d/1fdBcYvC7u7HpevM6BHqDmOXqVnpS-0woHAFzjTc-EiQ/edit#heading=h.tdev6kcteg3c.

cf #38 -- I've ignored the questions about mobile products so far; it's possible a separate `fenix_telemetry` key on the Feature interface will be the way we can cross that bridge once we get to it.

I just picked a place to shove this code; I don't have strong feelings about how this is organized if anyone feels it should live somewhere else.

I named the Feature interface FeatureInterface to avoid stepping on its definition as a string in the Experiment type; I'd welcome feedback on how to resolve that.