### PR TITLE
Add enrollment and duration to AA preset fixes #68

### DIFF
--- a/data/ExperimentDesignPresets.ts
+++ b/data/ExperimentDesignPresets.ts
@@ -20,6 +20,8 @@ const presets :  {[id: string] : Preset<ExperimentDesign> } = {
     name: "A/A Experiment",
     description: "A design for diagnostic testing of targeting or enrollment. Fixed to 1% of the population.",
     preset: {
+      proposedDuration: 28,
+      proposedEnrollment: 7,
       branches: [
         {slug: "control", ratio: 1, value: null},
         {slug: "treatment", ratio: 1, value: null}

--- a/data/experiment-recipe-samples/pull-factor.json
+++ b/data/experiment-recipe-samples/pull-factor.json
@@ -17,6 +17,7 @@
     },
     "startDate": "2020-06-17T23:20:47.230Z",
     "endDate": null,
+    "proposedDuration": 28,
     "proposedEnrollment": 7,
     "referenceBranch": "control",
     "features": [],

--- a/test/test-experiment-recipe-firefox.ts
+++ b/test/test-experiment-recipe-firefox.ts
@@ -20,6 +20,7 @@ const TEST_EXPERIMENT = {
     },
     "startDate": "2020-07-01T11:04:42z",
     "endDate": null,
+    "proposedDuration": 28,
     "proposedEnrollment": 7,
     "referenceBranch": "control",
     "features": [],

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -44,6 +44,8 @@ export interface Experiment {
    * @format date-time
    */
   endDate: string | null;
+  /** Duration of the experiment from the start date in days */
+  proposedDuration: number;
   /** Duration of enrollment from the start date in days */
   proposedEnrollment: number;
   /** The slug of the reference branch */


### PR DESCRIPTION
Adding proposed duration and enrollment to the AA preset based on feedback from @tdsmith: 

Enrollment: 7 days
Duration: 28 days