### PR TITLE
Add firefox channel to audiences fixes #60

### DIFF
--- a/data/Audiences.ts
+++ b/data/Audiences.ts
@@ -1,23 +1,26 @@
-import { Audience } from "../types/targeting";
+import { Audience, FirefoxChannel } from "../types/targeting";
 
 const audiences :  {[id: string] : Audience } = {
   all_english: {
     name: "All English users (release)",
     description: "All users in en-* locales using the release channel.",
     targeting: "localeLanguageCode == 'en' && browserSettings.update.channel == 'release'",
-    desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en') AND normalized_channel = 'release'"
+    desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en') AND normalized_channel = 'release'",
+    firefox_channel: FirefoxChannel.Release,
   },
   us_only: {
     name: "US users (en; release)",
     description: "All users in the US with an en-* locale using the release channel.",
     targeting: "localeLanguageCode == 'en' && region == 'US' && browserSettings.update.channel == 'release'",
-    desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en') AND normalized_country_code = 'US' AND normalized_channel = 'release'"
+    desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en') AND normalized_country_code = 'US' AND normalized_channel = 'release'",
+    firefox_channel: FirefoxChannel.Release,
   },
   first_run: {
     name: "First start-up users (en; release)",
     description: "First start-up users (e.g. for about:welcome) with an en-* locale using the release channel.",
     targeting: "localeLanguageCode == 'en' && (isFirstStartup || currentExperiment.slug in activeExperiments) && browserSettings.update.channel == 'release'",
-    desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en') AND payload.info.profile_subsession_counter = 1 AND normalized_channel = 'release'"
+    desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en') AND payload.info.profile_subsession_counter = 1 AND normalized_channel = 'release'",
+    firefox_channel: FirefoxChannel.Release,
   }
 };
 

--- a/data/Audiences.ts
+++ b/data/Audiences.ts
@@ -1,4 +1,4 @@
-import { Audience, FirefoxChannel } from "../types/targeting";
+import { Audience } from "../types/targeting";
 
 const audiences :  {[id: string] : Audience } = {
   all_english: {
@@ -6,21 +6,21 @@ const audiences :  {[id: string] : Audience } = {
     description: "All users in en-* locales using the release channel.",
     targeting: "localeLanguageCode == 'en' && browserSettings.update.channel == 'release'",
     desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en') AND normalized_channel = 'release'",
-    firefox_channel: FirefoxChannel.Release,
+    firefox_channel: "Release",
   },
   us_only: {
     name: "US users (en; release)",
     description: "All users in the US with an en-* locale using the release channel.",
     targeting: "localeLanguageCode == 'en' && region == 'US' && browserSettings.update.channel == 'release'",
     desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en') AND normalized_country_code = 'US' AND normalized_channel = 'release'",
-    firefox_channel: FirefoxChannel.Release,
+    firefox_channel: "Release",
   },
   first_run: {
     name: "First start-up users (en; release)",
     description: "First start-up users (e.g. for about:welcome) with an en-* locale using the release channel.",
     targeting: "localeLanguageCode == 'en' && (isFirstStartup || currentExperiment.slug in activeExperiments) && browserSettings.update.channel == 'release'",
     desktop_telemetry: "STARTS_WITH(environment.settings.locale, 'en') AND payload.info.profile_subsession_counter = 1 AND normalized_channel = 'release'",
-    firefox_channel: FirefoxChannel.Release,
+    firefox_channel: "Release",
   }
 };
 

--- a/types/targeting.ts
+++ b/types/targeting.ts
@@ -1,9 +1,3 @@
-export enum FirefoxChannel {
-  Nightly = "Nightly",
-  Beta = "Beta",
-  Release = "Release",
-}
-
 export interface Audience {
     name: string;
     description: string;
@@ -15,5 +9,5 @@ export interface Audience {
      * not for targeting.
      */
     desktop_telemetry?: string;
-    firefox_channel: FirefoxChannel;
+    firefox_channel: "Nightly" | "Beta" | "Release";
   }

--- a/types/targeting.ts
+++ b/types/targeting.ts
@@ -1,3 +1,9 @@
+export enum FirefoxChannel {
+  Nightly = "Nightly",
+  Beta = "Beta",
+  Release = "Release",
+}
+
 export interface Audience {
     name: string;
     description: string;
@@ -9,4 +15,5 @@ export interface Audience {
      * not for targeting.
      */
     desktop_telemetry?: string;
+    firefox_channel: FirefoxChannel;
   }


### PR DESCRIPTION
We added 'release' as part of the targeting expression but for Experimenter to mark it on an experiment we need to put it in its own field, rather than trying to parse it out of the filter expression. 