### PR TITLE
Add filter_expression and targeting to AA preset fixes #73

### DIFF
--- a/data/ExperimentDesignPresets.ts
+++ b/data/ExperimentDesignPresets.ts
@@ -23,9 +23,9 @@ const presets: { [id: string]: Preset<ExperimentRecipe> } = {
       "A design for diagnostic testing of targeting or enrollment. Fixed to 1% of the population.",
     preset: {
       filter_expression:
-        "env.version|versionCompare('{minFirefoxVersion}') >= 0 && {audience.filter_expression}",
+        "env.version|versionCompare('{minFirefoxVersion}') >= 0 && {audience_filter_expression}",
       targeting:
-        "[{randomizationUnit}, {bucketNamespace}]|bucketSample({bucketStart}, {bucketCount}, {totalBuckets}) && {audience.targeting}",
+        "[{randomizationUnit}, {bucketNamespace}]|bucketSample({bucketStart}, {bucketCount}, {bucketTotal}) && {audience_targeting}",
       arguments: {
         proposedDuration: 28,
         proposedEnrollment: 7,

--- a/data/ExperimentDesignPresets.ts
+++ b/data/ExperimentDesignPresets.ts
@@ -22,8 +22,7 @@ const presets: { [id: string]: Preset<ExperimentRecipe> } = {
     description:
       "A design for diagnostic testing of targeting or enrollment. Fixed to 1% of the population.",
     preset: {
-      filter_expression:
-        "env.version|versionCompare('{minFirefoxVersion}') >= 0 && {audienceFilterExpression}",
+      filter_expression: "env.version|versionCompare('{minFirefoxVersion}') >= 0",
       targeting:
         '[{randomizationUnit}, "{bucketNamespace}"]|bucketSample({bucketStart}, {bucketCount}, {bucketTotal}) && {audienceTargeting}',
       arguments: {

--- a/data/ExperimentDesignPresets.ts
+++ b/data/ExperimentDesignPresets.ts
@@ -23,9 +23,9 @@ const presets: { [id: string]: Preset<ExperimentRecipe> } = {
       "A design for diagnostic testing of targeting or enrollment. Fixed to 1% of the population.",
     preset: {
       filter_expression:
-        "env.version|versionCompare('{minFirefoxVersion}') >= 0 && {audience_filter_expression}",
+        "env.version|versionCompare('{minFirefoxVersion}') >= 0 && {audienceFilterExpression}",
       targeting:
-        "[{randomizationUnit}, {bucketNamespace}]|bucketSample({bucketStart}, {bucketCount}, {bucketTotal}) && {audience_targeting}",
+        "[{randomizationUnit}, {bucketNamespace}]|bucketSample({bucketStart}, {bucketCount}, {bucketTotal}) && {audienceTargeting}",
       arguments: {
         proposedDuration: 28,
         proposedEnrollment: 7,

--- a/data/ExperimentDesignPresets.ts
+++ b/data/ExperimentDesignPresets.ts
@@ -34,7 +34,7 @@ const presets: { [id: string]: Preset<ExperimentRecipe> } = {
           { slug: "treatment", ratio: 1, value: null },
         ],
         bucketConfig: {
-          randomizationUnit: "normandy_id",
+          randomizationUnit: "userId",
           count: 100,
           total: 10000,
         },

--- a/data/ExperimentDesignPresets.ts
+++ b/data/ExperimentDesignPresets.ts
@@ -25,7 +25,7 @@ const presets: { [id: string]: Preset<ExperimentRecipe> } = {
       filter_expression:
         "env.version|versionCompare('{minFirefoxVersion}') >= 0 && {audienceFilterExpression}",
       targeting:
-        "[{randomizationUnit}, {bucketNamespace}]|bucketSample({bucketStart}, {bucketCount}, {bucketTotal}) && {audienceTargeting}",
+        '[{randomizationUnit}, "{bucketNamespace}"]|bucketSample({bucketStart}, {bucketCount}, {bucketTotal}) && {audienceTargeting}',
       arguments: {
         proposedDuration: 28,
         proposedEnrollment: 7,

--- a/data/ExperimentDesignPresets.ts
+++ b/data/ExperimentDesignPresets.ts
@@ -1,4 +1,4 @@
-import { ExperimentDesign } from "../types/experiments";
+import { ExperimentRecipe } from "../types/experiments";
 
 // Utility type to being able to specify partials of nested objects
 type RecursivePartial<T> = {
@@ -16,22 +16,28 @@ interface Preset<T> {
   preset: RecursivePartial<T>;
 }
 
-const presets: { [id: string]: Preset<ExperimentDesign> } = {
+const presets: { [id: string]: Preset<ExperimentRecipe> } = {
   empty_aa: {
     name: "A/A Experiment",
     description:
       "A design for diagnostic testing of targeting or enrollment. Fixed to 1% of the population.",
     preset: {
-      proposedDuration: 28,
-      proposedEnrollment: 7,
-      branches: [
-        { slug: "control", ratio: 1, value: null },
-        { slug: "treatment", ratio: 1, value: null },
-      ],
-      bucketConfig: {
-        randomizationUnit: "normandy_id",
-        count: 100,
-        total: 10000,
+      filter_expression:
+        "env.version|versionCompare('{minFirefoxVersion}') >= 0 && {audience.filter_expression}",
+      targeting:
+        "[{randomizationUnit}, {bucketNamespace}]|bucketSample({bucketStart}, {bucketCount}, {totalBuckets}) && {audience.targeting}",
+      arguments: {
+        proposedDuration: 28,
+        proposedEnrollment: 7,
+        branches: [
+          { slug: "control", ratio: 1, value: null },
+          { slug: "treatment", ratio: 1, value: null },
+        ],
+        bucketConfig: {
+          randomizationUnit: "normandy_id",
+          count: 100,
+          total: 10000,
+        },
       },
     },
   },

--- a/docs/pages/content/schemas.tsx
+++ b/docs/pages/content/schemas.tsx
@@ -11,7 +11,7 @@ const SchemasPage: React.FunctionComponent = () => {
       <h1>Schema Groups</h1>
 
       <p>
-        This is the schemas exported by nimbus-shared. The source of these schemas is Typescript {" "}
+        This is the schemas exported by nimbus-shared. The source of these schemas is Typescript{" "}
         <a href={githubUrl}>on Github</a>.
       </p>
 

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -57,7 +57,7 @@ interface BucketConfig {
    * The randomization unit. Note that client_id is not yet implemented.
    * @default "normandy_id"
    */
-  randomizationUnit: "client_id" | "normandy_id";
+  randomizationUnit: "client_id" | "normandy_id" | "userId";
   /** Additional inputs to the hashing function */
   namespace: string;
   /**  Index of start of the range of buckets */

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -87,26 +87,3 @@ interface Branch {
   /** The variant payload. TODO: This will be more strictly validated. */
   value: { [key: string]: unknown } | null;
 }
-
-/**
- * Preset types
- * */
-
-// A union of all available experiment designs; right now there is only one.
-export type ExperimentDesign = EmptyAAExperiment;
-
-/**
- * An empty experiment that can target a maximum of 1% of the population
- */
-export interface EmptyAAExperiment extends Experiment {
-  branches: Array<EmptyBranch>;
-  bucketConfig: AABucketConfig;
-}
-
-interface AABucketConfig extends BucketConfig {
-  total: 10000;
-}
-
-interface EmptyBranch extends Branch {
-  value: null;
-}


### PR DESCRIPTION
So I changed the preset to extend the `ExperimentRecipe` instead of the `Experiment` and removed the design specific types since it added a layer of indirection to that whole jazz and we only have one right now so I don't think it added anything?  We can revisit it when we have more types? 