### PR TITLE
Added example of mobile A/A experiment

### DIFF
--- a/data/experiment-recipe-samples/mobile-a-a.json
+++ b/data/experiment-recipe-samples/mobile-a-a.json
@@ -1,0 +1,29 @@
+{
+  "slug": "mobile-a-a-example",
+  "application": "reference-browser",
+  "userFacingName": "Mobile A/A Example",
+  "userFacingDescription": "An A/A Test to validate the Rust SDK",
+  "isEnrollmentPaused": false,
+  "bucketConfig": {
+    "randomizationUnit": "nimbus_id",
+    "namespace": "mobile-a-a-example",
+    "start": 0,
+    "count": 5000,
+    "total": 10000
+  },
+  "startDate": null,
+  "endDate": null,
+  "proposedEnrollment": 7,
+  "referenceBranch": "control",
+  "probeSets": [],
+  "branches": [
+    {
+      "slug": "control",
+      "ratio": 1
+    },
+    {
+      "slug": "treatment-variation-b",
+      "ratio": 1
+    }
+  ]
+}


### PR DESCRIPTION
@rfk Since we were making some breaking changes anyway, I made a couple of adjustments to flatten the schema and remove some unused fields in https://github.com/mozilla/nimbus-shared/commit/3f9f88cf71caca2598013908b2de1c8e619cc128.

Previously we made the format compatible with Normandy but that is no longer a requirement.

Here's an example validated against the schema – also open to suggestions if you have them!