### PR TITLE
remove channels

### DIFF
--- a/data/experiment-recipe-samples/pull-factor.json
+++ b/data/experiment-recipe-samples/pull-factor.json
@@ -1,7 +1,6 @@
 {
   "slug": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
   "application": "firefox-desktop",
-  "channels": ["nightly"],
   "userFacingName": "About:Welcome Pull Factor Reinforcement",
   "userFacingDescription": "4 branch experiment different variants of about:welcome with a goal of testing new experiment framework and get insights on whether reinforcing pull-factors improves retention. Test deployment of multiple branches using new experiment framework",
   "isEnrollmentPaused": true,

--- a/test/test-experiment-recipe-firefox.ts
+++ b/test/test-experiment-recipe-firefox.ts
@@ -4,7 +4,6 @@ import { assert } from "chai";
 const TEST_EXPERIMENT = {
   slug: "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
   application: "firefox-desktop",
-  channels: ["nightly"],
   userFacingName: "About:Welcome Pull Factor Reinforcement",
   userFacingDescription:
     "4 branch experiment different variants of about:welcome with a goal of testing new experiment framework and get insights on whether reinforcing pull-factors improves retention. Test deployment of multiple branches using new experiment framework",

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -36,7 +36,7 @@ export interface NimbusExperiment {
   proposedEnrollment: number;
   /** The slug of the reference branch */
   referenceBranch: string | null;
-  /** A specific product such as Firefox Desktop or Fenix that supports Nimbus experimentst */
+  /** A specific product such as Firefox Desktop or Fenix that supports Nimbus experiments */
   application: string;
 }
 

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -4,11 +4,11 @@
 export interface NimbusExperiment {
   /** Unique identifier for the experiment */
   slug: string;
-  /** Publically-accesible name of the experiment */
+  /** Public name of the experiment displayed on "about:studies" */
   userFacingName: string;
-  /** Short public description of the experiment */
+  /** Short public description of the experiment displayed on on "about:studies" */
   userFacingDescription: string;
-  /** Are we continuing to enroll new users into the experiment? */
+  /** Should we enroll new users into the experiment? */
   isEnrollmentPaused: boolean;
   /** Bucketing configuration */
   bucketConfig: BucketConfig;
@@ -21,18 +21,21 @@ export interface NimbusExperiment {
    */
   targeting?: string;
   /**
-   * Actual publish date of the experiment
+   * Actual publish date of the experiment. Note that this value is expected to be null
+   * in Remote Settings.
    * @format date-time
    */
   startDate: string | null;
   /**
-   * Actual end date of the experiment
+   * Actual end date of the experiment. Note that this value is expected to be null
+   * in Remote Settings.
    * @format date-time
    */
   endDate: string | null;
   /** Duration of the experiment from the start date in days */
   proposedDuration?: number;
-  /** Duration of enrollment from the start date in days */
+  /** Duration of enrollment from the start date in days
+   */
   proposedEnrollment: number;
   /** The slug of the reference branch */
   referenceBranch: string | null;

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -38,8 +38,6 @@ export interface NimbusExperiment {
   referenceBranch: string | null;
   /** A specific product such as Firefox Desktop or Fenix that supports Nimbus experimentst */
   application: string;
-  /** Which channels should the application match? */
-  channels: Array<string>;
 }
 
 interface BucketConfig {


### PR DESCRIPTION
After starting to implementing this in Desktop, I realized this is going to be problematic for testing on unbranded builds etc.

Let's remove this until we've thought it through properly.