### PR TITLE
Add schemaVersion property

### DIFF
--- a/data/experiment-recipe-samples/mobile-a-a.json
+++ b/data/experiment-recipe-samples/mobile-a-a.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": "0.1.0",
   "id": "mobile-a-a-example",
   "slug": "mobile-a-a-example",
   "application": "reference-browser",

--- a/data/experiment-recipe-samples/pull-factor.json
+++ b/data/experiment-recipe-samples/pull-factor.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": "0.1.0",
   "id": "message-aboutwelcome-pull-factor-reinforcement",
   "slug": "message-aboutwelcome-pull-factor-reinforcement",
   "application": "firefox-desktop",

--- a/test/test-experiment-recipe-firefox.ts
+++ b/test/test-experiment-recipe-firefox.ts
@@ -1,47 +1,6 @@
 import { typeGuards } from "..";
 import { assert } from "chai";
-
-const TEST_EXPERIMENT = {
-  id: "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
-  slug: "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
-  application: "firefox-desktop",
-  userFacingName: "About:Welcome Pull Factor Reinforcement",
-  userFacingDescription:
-    "4 branch experiment different variants of about:welcome with a goal of testing new experiment framework and get insights on whether reinforcing pull-factors improves retention. Test deployment of multiple branches using new experiment framework",
-  isEnrollmentPaused: true,
-  bucketConfig: {
-    randomizationUnit: "normandy_id",
-    namespace: "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
-    start: 0,
-    count: 2000,
-    total: 10000,
-  },
-  startDate: null,
-  endDate: null,
-  proposedEnrollment: 7,
-  referenceBranch: "control",
-  probeSets: [],
-  branches: [
-    {
-      slug: "control",
-      ratio: 1,
-      feature: {
-        featureId: "cfr",
-        enabled: true,
-        value: null,
-      },
-    },
-    {
-      slug: "treatment-variation-b",
-      ratio: 1,
-      feature: {
-        featureId: "cfr",
-        enabled: true,
-        value: null,
-      },
-    },
-  ],
-};
+import TEST_EXPERIMENT from "../data/experiment-recipe-samples/pull-factor.json";
 
 describe("experiment schemas", () => {
   it("should validate an existing onboarding experiment", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "module": "CommonJS",
     "strict": true,
     "target": "ES2018",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   }
 }

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -4,6 +4,11 @@
  * 2. Jetstream via the Experimenter API
  */
 export interface NimbusExperiment {
+  /**
+   * Version of the NimbusExperiment schema this experiment refers to
+   */
+  schemaVersion: string;
+
   /** Unique identifier for the experiment */
   slug: string;
 


### PR DESCRIPTION
Fixes #130. I thought maybe `schemaVersion` would be more specific about what it refers to.

See #135 for an ADR that discusses how this would be used.