### PR TITLE
fix #146 feat(project): add channel to experiment type

### DIFF
--- a/data/experiment-recipe-samples/cfr-82-83.json
+++ b/data/experiment-recipe-samples/cfr-82-83.json
@@ -2,6 +2,7 @@
   "id": "bug-1671620-message-homepage-remediation-search-value-props-exper-release-82-83",
   "schemaVersion": "1.0.0",
   "application": "firefox-desktop",
+  "channel": "nightly",
   "probeSets": [],
   "startDate": null,
   "endDate": null,

--- a/data/experiment-recipe-samples/mobile-a-a.json
+++ b/data/experiment-recipe-samples/mobile-a-a.json
@@ -3,6 +3,7 @@
   "id": "mobile-a-a-example",
   "slug": "mobile-a-a-example",
   "application": "reference-browser",
+  "channel": "nightly",
   "userFacingName": "Mobile A/A Example",
   "userFacingDescription": "An A/A Test to validate the Rust SDK",
   "isEnrollmentPaused": false,

--- a/data/experiment-recipe-samples/pull-factor.json
+++ b/data/experiment-recipe-samples/pull-factor.json
@@ -3,6 +3,7 @@
   "id": "message-aboutwelcome-pull-factor-reinforcement",
   "slug": "message-aboutwelcome-pull-factor-reinforcement",
   "application": "firefox-desktop",
+  "channel": "nightly",
   "userFacingName": "About:Welcome Pull Factor Reinforcement",
   "userFacingDescription": "4 branch experiment different variants of about:welcome with a goal of testing new experiment framework and get insights on whether reinforcing pull-factors improves retention. Test deployment of multiple branches using new experiment framework",
   "isEnrollmentPaused": true,

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -21,6 +21,9 @@ export interface NimbusExperiment {
   /** A specific product such as Firefox Desktop or Fenix that supports Nimbus experiments */
   application: string;
 
+  /** A specific channel of an application such as Nightly, Beta, or Release */
+  channel: string;
+
   /** Public name of the experiment displayed on "about:studies" */
   userFacingName: string;
 


### PR DESCRIPTION
Because

* Automated analysis requires the channel to be exposed in the experiment DTO

This commit

* Adds channel: string to the experiment type