### PR TITLE
Add outcomes to DTO

### DIFF
--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -62,7 +62,7 @@ export interface NimbusExperiment {
   probeSets: Array<string>;
 
   /** A list of outcomes relevant to the experiment analysis. */
-  outcomes: Array<Outcome>;
+  outcomes?: Array<Outcome>;
 
   /** A list of featureIds the experiment contains configurations for.
    */

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -55,8 +55,14 @@ export interface NimbusExperiment {
   /** Bucketing configuration */
   bucketConfig: BucketConfig;
 
-  /** A list of probe set slugs relevant to the experiment analysis */
+  /** A list of probe set slugs relevant to the experiment analysis
+   * Deprecated and should always be an empty list as of v1.4.
+   * Will be removed in the next major version.
+   */
   probeSets: Array<string>;
+
+  /** A list of outcomes relevant to the experiment analysis. */
+  outcomes: Array<Outcome>;
 
   /** A list of featureIds the experiment contains configurations for.
    */
@@ -161,4 +167,12 @@ interface Branch {
   ratio: number;
 
   feature?: FeatureConfig;
+}
+
+interface Outcome {
+  /** Identifier for the outcome */
+  slug: string;
+
+  /** e.g. "primary" or "secondary" */
+  priority: string;
 }


### PR DESCRIPTION
Alternatives here are:
* Just keep using "probeSets"
* Use an array of bare slugs

I think using an array of objects is more flexible in case we want to add more annotations later but maybe YAGNI. The use case I'm envisioning is letting someone identify all the experiments that had a given outcome as a primary outcome.