### PR TITLE
Feature value should not be null

### DIFF
--- a/data/ExperimentDesignPresets.ts
+++ b/data/ExperimentDesignPresets.ts
@@ -27,11 +27,11 @@ const presets: { [id: string]: Preset<NimbusExperiment> } = {
       proposedDuration: 28,
       proposedEnrollment: 7,
       branches: [
-        { slug: "control", ratio: 1, feature: { featureId: "cfr", enabled: true, value: null } },
+        { slug: "control", ratio: 1, feature: { featureId: "cfr", enabled: true, value: {} } },
         {
           slug: "treatment",
           ratio: 1,
-          feature: { featureId: "cfr", enabled: true, value: null },
+          feature: { featureId: "cfr", enabled: true, value: {} },
         },
       ],
       bucketConfig: {

--- a/data/experiment-recipe-samples/mobile-a-a.json
+++ b/data/experiment-recipe-samples/mobile-a-a.json
@@ -30,7 +30,7 @@
       "feature": {
         "featureId": "bookmarkId",
         "enabled": true,
-        "value": null
+        "value": {}
       }
     },
     {
@@ -39,7 +39,7 @@
       "feature": {
         "featureId": "bookmarkId",
         "enabled": true,
-        "value": null
+        "value": {}
       }
     }
   ]

--- a/data/experiment-recipe-samples/pull-factor.json
+++ b/data/experiment-recipe-samples/pull-factor.json
@@ -27,12 +27,12 @@
     {
       "slug": "control",
       "ratio": 1,
-      "feature": { "featureId": "cfr", "enabled": true, "value": null }
+      "feature": { "featureId": "cfr", "enabled": true, "value": {} }
     },
     {
       "slug": "treatment-variation-b",
       "ratio": 1,
-      "feature": { "featureId": "cfr", "enabled": true, "value": null }
+      "feature": { "featureId": "cfr", "enabled": true, "value": {} }
     }
   ]
 }

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -151,7 +151,7 @@ interface FeatureConfig {
   enabled: boolean;
 
   /** Optional extra params for the feature (this should be validated against a schema) */
-  value: { [key: string]: unknown } | null;
+  value: { [key: string]: unknown };
 }
 
 interface Branch {
@@ -166,7 +166,7 @@ interface Branch {
    */
   ratio: number;
 
-  feature?: FeatureConfig;
+  feature: FeatureConfig;
 }
 
 interface Outcome {


### PR DESCRIPTION
Because remote settings does not expect `feature_value` to be `null`, but rather always an object, we should remove it from the schema altogether.