### PR TITLE
Support legacy single feature configuration

### DIFF
--- a/data/experiment-recipe-samples/desktop-92.json
+++ b/data/experiment-recipe-samples/desktop-92.json
@@ -3,6 +3,12 @@
   "appName": "firefox_desktop",
   "branches": [
     {
+      "feature": {
+        "featureId": "privatebrowsing",
+        "value": {
+          "promoLinkUrl": "https://vpn.mozilla.org/?utm_campaign=private-browsing-vpn-link&entrypoint_experiment=firefox-vpn-test-1629&entrypoint_variation=control"
+        }
+      },
       "features": [{
         "featureId": "privatebrowsing",
         "value": {
@@ -13,6 +19,12 @@
       "slug": "control"
     },
     {
+      "feature": {
+        "featureId": "privatebrowsing",
+        "value": {
+          "promoLinkUrl": "https://vpn.mozilla.org/?utm_campaign=private-browsing-vpn-link&entrypoint_experiment=firefox-vpn-test-1629&entrypoint_variation=control"
+        }
+      },
       "features": [{
         "featureId": "privatebrowsing",
         "value": {
@@ -32,6 +44,12 @@
       "slug": "var1"
     },
     {
+      "feature": {
+        "featureId": "privatebrowsing",
+        "value": {
+          "promoLinkUrl": "https://vpn.mozilla.org/?utm_campaign=private-browsing-vpn-link&entrypoint_experiment=firefox-vpn-test-1629&entrypoint_variation=control"
+        }
+      },
       "features": [{
         "featureId": "privatebrowsing",
         "value": {

--- a/data/experiment-recipe-samples/desktop-95.json
+++ b/data/experiment-recipe-samples/desktop-95.json
@@ -1,0 +1,83 @@
+{
+  "slug": "testing-multifeature-desktop",
+  "appId": "firefox-desktop",
+  "appName": "firefox_desktop",
+  "channel": "",
+  "endDate": null,
+  "branches": [
+    {
+      "slug": "control",
+      "ratio": 1,
+      "feature": {
+        "value": {},
+        "enabled": true,
+        "featureId": "no-feature-firefox-desktop"
+      },
+      "features": [
+        {
+          "value": {
+            "enabled": false
+          },
+          "featureId": "aboutwelcome"
+        },
+        {
+          "value": {
+            "infoTitle": "This is control",
+            "infoTitleEnabled": true
+          },
+          "featureId": "privatebrowsing"
+        }
+      ]
+    },
+    {
+      "slug": "treatment-a",
+      "ratio": 1,
+      "feature": {
+        "value": {},
+        "enabled": true,
+        "featureId": "no-feature-firefox-desktop"
+      },
+      "features": [
+        {
+          "value": {
+            "enabled": false
+          },
+          "featureId": "aboutwelcome"
+        },
+        {
+          "value": {
+            "infoTitle": "This is treatment",
+            "infoTitleEnabled": true
+          },
+          "featureId": "privatebrowsing"
+        }
+      ]
+    }
+  ],
+  "outcomes": [],
+  "arguments": {},
+  "probeSets": [],
+  "startDate": null,
+  "targeting": "version|versionCompare('95.!') >= 0 && 'app.shield.optoutstudies.enabled'|preferenceValue",
+  "featureIds": [
+    "privatebrowsing",
+    "aboutwelcome"
+  ],
+  "application": "firefox-desktop",
+  "bucketConfig": {
+    "count": 5000,
+    "start": 0,
+    "total": 10000,
+    "namespace": "firefox-desktop-no-feature-firefox-desktop-2",
+    "randomizationUnit": "normandy_id"
+  },
+  "schemaVersion": "1.5.0",
+  "userFacingName": "Testing Multifeature Desktop",
+  "referenceBranch": "control",
+  "proposedDuration": 28,
+  "isEnrollmentPaused": false,
+  "proposedEnrollment": 7,
+  "userFacingDescription": "Testing Multifeature Desktop",
+  "id": "testing-multifeature-desktop",
+  "last_modified": 1635342922069
+}

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -58,7 +58,7 @@ export interface NimbusExperiment {
   featureIds?: Array<string>;
 
   /** Branch configuration for the experiment */
-  branches: Array<Branch | SingleFeatureBranch>;
+  branches: Array<Branch>;
 
   /**
    * JEXL expression used to filter experiments based on locale, geo, etc.
@@ -156,14 +156,14 @@ interface Branch {
   ratio: number;
 
   /**
-   * Legacy support
-   */
+  * Firefox Desktop <95
+  */
   feature: FeatureConfig;
-  
+
   /**
-   * Firefox Desktop 95+
-   */
-  features: Array<FeatureConfig>;
+  * Firefox Desktop >=95
+  */
+  features?: Array<FeatureConfig>;
 }
 
 interface Outcome {


### PR DESCRIPTION
Because

* We want recipes that target multifeature to be backwards compatible with earlier clients that expect only a single feature

This commit

* Includes both the feature and features keys in each branch configuration