### PR TITLE
EXP-1865 add isRollout boolean property to Experiment type

### DIFF
--- a/test/test-experiment-recipe-firefox.ts
+++ b/test/test-experiment-recipe-firefox.ts
@@ -14,6 +14,14 @@ describe("experiment schemas", () => {
     assert.equal(result.ok, false, "validation should fail");
     assert.propertyVal(result.errors[0], "message", 'should match format "date"');
   });
+  it("should fail on a non-boolean for a boolean", async () => {
+    const result = typeGuards.experiments_checkNimbusExperiment({
+      ...TEST_EXPERIMENT,
+      isRollout: "foo",
+    });
+    assert.equal(result.ok, false, "validation should fail");
+    assert.propertyVal(result.errors[0], "message", "should be boolean");
+  });
   it("should fail on a non-integer value for a number", async () => {
     const result = typeGuards.experiments_checkNimbusExperiment({
       ...TEST_EXPERIMENT,

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -47,6 +47,14 @@ export interface NimbusExperiment {
    */
   isEnrollmentPaused: boolean;
 
+  /**
+   * When this property is set to true, treat this experiment as a rollout.
+   * Rollouts are currently handled as single-branch experiments separated
+   * from the bucketing namespace for normal experiments.
+   * See also: https://mozilla-hub.atlassian.net/browse/SDK-405
+   */
+  isRollout?: boolean;
+
   /** Bucketing configuration */
   bucketConfig: BucketConfig;
 


### PR DESCRIPTION
Because:

* we want to implement support for an isRollout flag in experiments

This commit:

* adds an isRollout boolean to the NimbusExperiment type

* introduces example recipes for both mobile and desktop for testing