### PR TITLE
Remove the feature.enabled field from the FeatureConfig definition

### DIFF
--- a/data/ExperimentDesignPresets.ts
+++ b/data/ExperimentDesignPresets.ts
@@ -27,11 +27,11 @@ const presets: { [id: string]: Preset<NimbusExperiment> } = {
       proposedDuration: 28,
       proposedEnrollment: 7,
       branches: [
-        { slug: "control", ratio: 1, feature: { featureId: "cfr", enabled: true, value: {} } },
+        { slug: "control", ratio: 1, feature: { featureId: "cfr", value: {} } },
         {
           slug: "treatment",
           ratio: 1,
-          feature: { featureId: "cfr", enabled: true, value: {} },
+          feature: { featureId: "cfr", value: {} },
         },
       ],
       bucketConfig: {

--- a/data/experiment-recipe-samples/desktop-98.json
+++ b/data/experiment-recipe-samples/desktop-98.json
@@ -1,0 +1,79 @@
+{
+  "appId": "firefox-desktop",
+  "appName": "firefox_desktop",
+  "application": "firefox-desktop",
+  "arguments": {},
+  "branches": [
+    {
+      "feature": {
+        "featureId": "unused-feature-id-for-legacy-support",
+        "enabled": false,
+        "value": {}
+      },
+      "features": [
+        {
+          "featureId": "pocketNewtab",
+          "value": { "enabled": "true" }
+        },
+        {
+          "featureId": "upgradeDialog",
+          "value": {
+            "enabled": false
+          }
+        }
+      ],
+      "ratio": 1,
+      "slug": "control"
+    },
+    {
+      "feature": {
+        "featureId": "unused-feature-id-for-legacy-support",
+        "enabled": false,
+        "value": {}
+      },
+      "features": [
+        {
+          "featureId": "pocketNewtab",
+          "value": {
+            "enabled": true,
+            "compactLayout": true,
+            "lastCardMessageEnabled": true,
+            "loadMore": true,
+            "newFooterSection": true
+          }
+        },
+        {
+          "featureId": "upgradeDialog",
+          "value": {
+            "enabled": true
+          }
+        }
+      ],
+      "ratio": 1,
+      "slug": "treatment"
+    }
+  ],
+  "bucketConfig": {
+    "count": 10000,
+    "namespace": "firefox-desktop-multifeature-test",
+    "randomizationUnit": "normandy_id",
+    "start": 0,
+    "total": 10000
+  },
+  "channel": "nightly",
+  "endDate": null,
+  "featureIds": ["upgradeDialog", "pocketNewtab"],
+  "id": "mr2-upgrade-spotlight-holdback",
+  "isEnrollmentPaused": false,
+  "outcomes": [],
+  "probeSets": [],
+  "proposedDuration": 63,
+  "proposedEnrollment": 7,
+  "referenceBranch": "control",
+  "schemaVersion": "1.7.1",
+  "slug": "firefox-desktop-multifeature-test",
+  "startDate": "2021-10-26",
+  "targeting": "true",
+  "userFacingDescription": "Experimenting on onboarding content when you upgrade Firefox.",
+  "userFacingName": "MR2 Upgrade Spotlight Holdback"
+}

--- a/test/test-experiment-recipe-firefox.ts
+++ b/test/test-experiment-recipe-firefox.ts
@@ -1,6 +1,13 @@
 import { typeGuards } from "..";
 import { assert } from "chai";
-import TEST_EXPERIMENT from "../data/experiment-recipe-samples/desktop-90.json";
+import TEST_LEGACY_EXPERIMENT from "../data/experiment-recipe-samples/desktop-90.json";
+import TEST_EXPERIMENT from "../data/experiment-recipe-samples/desktop-98.json";
+
+describe("experiment schemas legacy", () => {
+  it("should validate an existing onboarding experiment", async () => {
+    typeGuards.experiments_assertNimbusExperiment(TEST_LEGACY_EXPERIMENT);
+  });
+});
 
 describe("experiment schemas", () => {
   it("should validate an existing onboarding experiment", async () => {

--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -154,9 +154,6 @@ interface FeatureConfig {
   /** The identifier for the feature flag */
   featureId: string;
 
-  /** This can be used to turn the whole feature on/off */
-  enabled?: boolean;
-
   /** Optional extra params for the feature (this should be validated against a schema) */
   value: { [key: string]: unknown };
 }


### PR DESCRIPTION
This field was deprecated for some time and now we're finally removing it.