### PR TITLE
fix #200 feat: add enrollmentEndDate to experiment type

### DIFF
--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -85,6 +85,13 @@ export interface NimbusExperiment {
   startDate: string | null;
 
   /**
+   * Actual enrollment end date of the experiment.
+   * Note that this value is expected to be null in Remote Settings.
+   * @format date
+   */
+  enrollmentEndDate?: string | null;
+
+  /**
    * Actual end date of the experiment.
    * Note that this value is expected to be null in Remote Settings.
    * @format date


### PR DESCRIPTION
Because

* Jetstream needs to know the actual enrollment end date to determine the set of enrolled clients to analyze
* The actual enrollment end date may be different from the proposed enrollment end date

This commit

* Adds enrollmentEndDate to the experiment type
* This field will only be consumed by Jetstream
* This field has no impact on client behaviour