### PR TITLE
Remove Experiment.filter_expression

### DIFF
--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -114,12 +114,6 @@ export interface NimbusExperiment {
 
   /** The slug of the reference branch (that is, which branch we consider "control") */
   referenceBranch: string | null;
-
-  /**
-   * This is NOT used by Nimbus, but has special functionality in Remote Settings.
-   * See https://remote-settings.readthedocs.io/en/latest/target-filters.html#how
-   */
-  filter_expression?: string;
 }
 
 interface BucketConfig {


### PR DESCRIPTION
This field was used by the messaging system, but hasn't been been used
for ~2 years.