### PR TITLE
Support multi-message branch configurations

### DIFF
--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -151,8 +151,8 @@ interface FeatureConfig {
   /** The identifier for the feature flag */
   featureId: string;
 
-  /** Optional extra params for the feature (this should be validated against a schema) */
-  value: { [key: string]: unknown };
+  /** Optional extra data for the feature (this should be validated against a schema) */
+  value: { [key: string]: unknown } | Array<unknown>;
 }
 
 interface SingleFeatureBranch {


### PR DESCRIPTION
Necessary to resolve [bug 1804480](https://bugzilla.mozilla.org/show_bug.cgi?id=1804480): 
"Add support for multi-message treatment branches in desktop experiments"