### PR TITLE
fix #239: make localizations nullable

### DIFF
--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -128,7 +128,7 @@ export interface NimbusExperiment {
    */
   localizations?: {
     [locale: string]: Record<string, string>;
-  };
+  } | null;
 }
 
 interface BucketConfig {


### PR DESCRIPTION
Because

* We want the localizations field to be nullable so the key can be present even if there's no localizations

This commit

* Makes the localizations field nullable