### PR TITLE
fix #250: locales can be null

### DIFF
--- a/types/experiments.ts
+++ b/types/experiments.ts
@@ -136,7 +136,7 @@ export interface NimbusExperiment {
    *
    * If null, all locales are targeted.
    */
-  locales?: string[];
+  locales?: string[] | null;
 }
 
 interface BucketConfig {


### PR DESCRIPTION
Because

* We want the locales field to be nullable

This commit

* Adds null to the locales field type